### PR TITLE
Update live metro rail vehicle locations legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -540,7 +540,7 @@ window.onload = function() {
 <div style="display: flex; justify-content: flex-end; align-items: center;">
     <a class="issues" href="https://github.com/LACMTA/realtime-map" target="_blank" style="display: flex; align-items: center; text-decoration: none; color: inherit;">
         <i class="fab fa-github" style="margin-right: 5px;"></i>
-        <a href="https://github.com/LACMTA/realtime-map" style="text-decoration: none;" target="_blank">Spot an issue?</a>
+        <a href="https://github.com/LACMTA/realtime-map/issues" style="text-decoration: none;" target="_blank">Spot an issue?</a>
     </a>
 </div>
     <button id="toggle-legend"><i class="fas fa-chevron-left"></i></button>

--- a/index.html
+++ b/index.html
@@ -497,7 +497,7 @@ window.onload = function() {
 
 </script>
 <div id="legend" style="background-color: #fff; padding: 10px; position: absolute; bottom: 50px; right: 10px; z-index: 1; transition: right 0.5s;">
-    <h4>Metro Live Rail Vehicle Locations</h4>
+    <h4>Live Metro Rail Vehicle Locations</h4>
     <div style="display: flex; align-items: center;">
         <img src="https://lacmta.github.io/metro-iconography/Arrow.svg" width="20" height="20" style="transform: rotate(-90deg); margin-right: 10px; margin-left: 10px;">
         Rail Vehicle
@@ -538,18 +538,18 @@ window.onload = function() {
     </div>
 <div id="update-time"></div>
 <div style="display: flex; justify-content: flex-end; align-items: center;">
-    <a class="issues" href="https://github.com/LACMTA/realtime-map/issues" target="_blank" style="display: flex; align-items: center; text-decoration: none; color: inherit;">
+    <a class="issues" href="https://github.com/LACMTA/realtime-map" target="_blank" style="display: flex; align-items: center; text-decoration: none; color: inherit;">
         <i class="fab fa-github" style="margin-right: 5px;"></i>
-        Spot an issue?
+        <a href="https://github.com/LACMTA/realtime-map" style="text-decoration: none;" target="_blank">Spot an issue?</a>
     </a>
 </div>
     <button id="toggle-legend"><i class="fas fa-chevron-left"></i></button>
 </div>
 
-<div id="loading" style="cursor:default;position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); padding: 10px; background-color: rgba(0, 0, 0, 0.5); color: white; border-radius: 5px; z-index: 9999;">
+
+</div><div id="loading" style="cursor:default;position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); padding: 10px; background-color: rgba(0, 0, 0, 0.5); color: white; border-radius: 5px; z-index: 9999;">
     Loading live data 
     <span class="dot">.</span><span class="dot">.</span><span class="dot">.</span>
-</div>
 </div>
 </body>
 <script>


### PR DESCRIPTION
This pull request updates the legend for live metro rail vehicle locations on the LACMTA realtime-map. The title of the legend has been changed from "Metro Live Rail Vehicle Locations" to "Live Metro Rail Vehicle Locations" for clarity. Additionally, the link to report issues has been updated to point to the correct repository.