### PR TITLE
Fix media query for small screens toggle legend and add z-index to button

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,12 @@
     cursor: pointer;
 }
 
+
+@media screen and (max-width: 600px) {
+    #toggle-legend {
+        left: 0; /* Position the element at the left edge of the screen on small screens */
+    }
+}
 #toggle-legend i {
     font-size: 12px; /* Adjust as needed */
 }

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     transform: translateX(0);
     cursor: pointer;
     padding: 0;
+    z-index: 9999;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
Previously, the media query for small screens toggle legend was not working correctly, causing issues with the layout on mobile devices. This PR fixes the media query to properly position the toggle legend on small screens.

Additionally, a z-index has been added to the button to ensure it appears above other elements on the page.

Fixes #1234