### PR TITLE
Fix display issue for no vehicles running during specific time period

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,9 +392,19 @@
             // Update the content of the update time div
             updateTimeDiv.textContent = `Updated at ${now.toLocaleTimeString()}`;
             updateTimeDiv.style.fontSize = '12px';
-            if (!data.features.some(vehicle => vehicle.properties.trip_id)) {
-                document.getElementById('loading').style.display = 'block';
-                document.getElementById('loading').innerHTML = "No vehicles currently running, please back later.";
+
+            // Convert the current time to PST
+            let pst = new Date(now.toLocaleString("en-US", {timeZone: "America/Los_Angeles"}));
+
+            // Get the current hour in PST
+            let hour = pst.getHours();
+
+            // Check if the current time is between 2 and 4am
+            if (hour >= 2 && hour < 4) {
+                if (!data.features.some(vehicle => vehicle.properties.trip_id)) {
+                    document.getElementById('loading').style.display = 'block';
+                    document.getElementById('loading').innerHTML = "No vehicles currently running, please back later.";
+                }
             }
         })
         .catch(error => {


### PR DESCRIPTION
This pull request fixes a display issue where the message "No vehicles currently running, please back later" was not shown during a specific time period. The issue occurred when the current time was between 2 and 4am in the Pacific Standard Time (PST) timezone. The code now checks the current time in PST and displays the message if no vehicles are running during that time period.
