### PR TITLE
Fix display issue for no vehicles running during specific time period

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,9 +392,19 @@
             // Update the content of the update time div
             updateTimeDiv.textContent = `Updated at ${now.toLocaleTimeString()}`;
             updateTimeDiv.style.fontSize = '12px';
-            if (!data.features.some(vehicle => vehicle.properties.trip_id)) {
-                document.getElementById('loading').style.display = 'block';
-                document.getElementById('loading').innerHTML = "No vehicles currently running, please back later.";
+
+            // Convert the current time to PST
+            let pst = new Date(now.toLocaleString("en-US", {timeZone: "America/Los_Angeles"}));
+
+            // Get the current hour in PST
+            let hour = pst.getHours();
+
+            // Check if the current time is between 2 and 4am
+            if (hour >= 2 && hour < 4) {
+                if (!data.features.some(vehicle => vehicle.properties.trip_id)) {
+                    document.getElementById('loading').style.display = 'block';
+                    document.getElementById('loading').innerHTML = "No vehicles currently running, please back later.";
+                }
             }
         })
         .catch(error => {

--- a/index.html
+++ b/index.html
@@ -148,7 +148,13 @@
     
     // Get the current time
     const now = new Date();
-    
+
+    // Convert the current time to PST
+    let pst = new Date(now.toLocaleString("en-US", {timeZone: "America/Los_Angeles"}));
+
+    // Get the current hour in PST
+    let hour = pst.getHours();
+
     // map setup
     
       let map = new maplibregl.Map({
@@ -217,13 +223,19 @@
             let newVehicleIds = new Set(data.features.map(vehicle => vehicle.properties.vehicle_id));
 
             // Remove markers that are not in the new data
-            for (let vehicle_id in markers) {
-                if (!newVehicleIds.has(vehicle_id)) {
-                    // The marker is not in the new data, remove it from the map
-                    markers[vehicle_id].remove();
-    
-                    // Delete the marker from the markers object
-                    delete markers[vehicle_id];
+            // Check if data is blank
+            if (data.features.length > 0) {
+                let newVehicleIds = new Set(data.features.map(vehicle => vehicle.properties.vehicle_id));
+
+                // Remove markers that are not in the new data
+                for (let vehicle_id in markers) {
+                    if (!newVehicleIds.has(vehicle_id)) {
+                        // The marker is not in the new data, remove it from the map
+                        markers[vehicle_id].remove();
+
+                        // Delete the marker from the markers object
+                        delete markers[vehicle_id];
+                    }
                 }
             }
             // For each vehicle in the data


### PR DESCRIPTION
This pull request fixes a display issue where the message "No vehicles currently running, please back later." was not shown during a specific time period. The issue occurred when the current time was between 2 and 4am in the Pacific Standard Time (PST) timezone. The code now checks the current hour in PST and displays the message if no vehicles are running. This improves the user experience by providing accurate information about the availability of vehicles.
