### PR TITLE
Fix weird heading flip

### DIFF
--- a/websocket.js
+++ b/websocket.js
@@ -594,7 +594,7 @@ function updateMarkerRotations() {
         const bearing = marker.properties.Heading;
 
         // Adjust the bearing by 180 degrees
-        const adjustedBearing = (bearing - 180) % 360;
+        const adjustedBearing = (bearing) % 360;
 
         // Calculate the final bearing based on the map's bearing
         const finalBearing = (adjustedBearing - mapBearing);


### PR DESCRIPTION
This pull request fixes a bug where the heading of a marker was flipped incorrectly. The bug was caused by an incorrect calculation of the adjusted bearing. This PR updates the calculation to correctly adjust the bearing without flipping it.