### PR TITLE
Refactor WebSocket visibility change handling and marker cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>Metro Live Map</title>
+  <title>Metro Live Map - Beta</title>
 <meta property="og:description" content="Real-time bus locations for Metro." />  <meta charset='utf-8'>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel='stylesheet' href='https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css' />

--- a/websocket.js
+++ b/websocket.js
@@ -377,11 +377,26 @@ function setupWebSocket(url, processData) {
 
     // Handle visibility change
     document.addEventListener('visibilitychange', function() {
-        if (!document.hidden && pendingData) {
+        if (!document.hidden) {
             // The tab has become visible again
-            // Process the pending data
-            processAndUpdate(pendingData);
-            pendingData = null;
+            // Process the pending data if it exists
+            if (pendingData) {
+                processAndUpdate(pendingData);
+                pendingData = null;
+            }
+
+            // Cleanup old markers
+            const oneMinuteAgo = Date.now() - 60 * 1000; // 1 minute in milliseconds
+            const newData = markers.features.filter(feature => {
+                // Only keep features with a timestamp in the last minute
+                return feature.properties.timestamp > oneMinuteAgo;
+            });
+
+            // Update the data for the layer
+            map.getSource('markers').setData({
+                type: 'FeatureCollection',
+                features: newData
+            });
         }
     });
 }


### PR DESCRIPTION
This pull request refactors the WebSocket visibility change handling and adds marker cleanup functionality. It ensures that when the tab becomes visible again, the pending data is processed and the markers are updated. Additionally, it cleans up old markers by removing features with timestamps older than one minute.