### PR TITLE
Refactor marker size to 16 pixels

### DIFF
--- a/websocket.js
+++ b/websocket.js
@@ -562,7 +562,7 @@ function createNewMarker(vehicle, features) {
     el.style.cursor = 'pointer';
 
     const zoom = map.getZoom();
-    const size = 40; // Set the size to a constant value
+    const size = 16; // Set the size to a constant value
 
     el.style.width = `${size}px`;
     el.style.height = `${size}px`;


### PR DESCRIPTION
This pull request refactors the marker size to a constant value of 16 pixels, improving consistency and reducing the marker size.