### PR TITLE
Update og:description meta tag in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <title>Metro Live Map - Beta</title>
-<meta property="og:description" content="Real-time bus locations for Metro." />  <meta charset='utf-8'>
+<meta property="og:description" content="Live rail and bus way vehicles for Los Angeles Metro." />  <meta charset='utf-8'>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel='stylesheet' href='https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css' />
   <script src='https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js'></script>


### PR DESCRIPTION
This pull request updates the og:description meta tag in the index.html file to display "Live rail and bus way vehicles for Los Angeles Metro" instead of "Real-time bus locations for Metro".