### PR TITLE
Add compact attribution control

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="styles/index-style.css">
+	<script async src="https://siteimproveanalytics.com/js/siteanalyze_6034017.js"></script>
 </head>
 
 <body>

--- a/websocket.js
+++ b/websocket.js
@@ -793,3 +793,8 @@ map.addControl(geolocate, 'top-left');
 geolocate.on('geolocate', function(e) {
     map.flyTo({center: [e.coords.longitude, e.coords.latitude], zoom: 14});
 });
+
+
+map.addControl(new maplibregl.AttributionControl({
+    compact: true
+}));


### PR DESCRIPTION
This pull request adds a compact attribution control to the map. The `compact` option is set to true, which reduces the size of the attribution control.